### PR TITLE
Fix OpenMPI init error in tests; bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ build:
     - vasp-create-hi-pass-viz = vasp.postprocessing.postprocessing_h5py.create_hi_pass_viz:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -62,6 +62,9 @@ test:
     # See: https://github.com/conda-forge/fenics-feedstock/pull/256
     # - pip check
 
+    # Avoid OpenMPI errors when running mpi4py in isolated environments
+    - export OMPI_MCA_plm=isolated
+
     # Check that all CLI entry points are available
     - vasp-generate-mesh --help
     - vasp-generate-solid-probe --help
@@ -76,9 +79,6 @@ test:
     - vasp-create-spectrograms-chromagrams --help
     - vasp-create-spectrum --help
     - vasp-create-hi-pass-viz --help
-
-    # Avoid OpenMPI errors when running mpi4py in isolated environments
-    - export OMPI_MCA_plm=isolated
 
     # Only a small subset of fast and representative tests are run here
     # to reduce test time in conda-forge CI


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes test failure on `linux_64` due to `mpi4py` triggering an OpenMPI init error. Moves `export OMPI_MCA_plm=isolated` before test commands that invoke MPI.

<!--
Please add any other relevant info below:
-->

This change ensures `MPI_INIT` succeeds in isolated environments like conda-forge CI containers.
