### PR TITLE
Pin VTK to GUI qt_* variant to fix missing viewer windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
   run:
     - python >={{ python_min }}
     - fenics >=2019.1.0
+    - sympy <1.12  # FEniCS 2019.1 JIT fails with SymPy ≥1.12 ("TypeError: derivative of <class 'list'>")
     - vmtk
     - morphman
     - paramiko

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ build:
     - vasp-create-hi-pass-viz = vasp.postprocessing.postprocessing_h5py.create_hi_pass_viz:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -50,6 +50,8 @@ requirements:
     - mpi4py ==3.1.4
     - turtlefsi
     - vampy
+    # Ensure GUI-capable VTK (Qt-backed, avoids osmesa/egl)
+    - vtk >=9,<10 qt_*
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review.
-->

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (version unchanged)

---

This PR constrains VTK to the Qt GUI variant (`qt_*`) to prevent headless `osmesa_*` builds that cause `vmtksurfaceviewer` and similar tools to show no window.

**Changes:**
- Add `vtk >=9,<10 qt_*` to runtime requirements.
- Bump build number from 0 → 1.
- Verified locally: `vmtksurfaceviewer` now opens a window.

Fixes the “no window” issue when VASP is installed via `conda create -n vasp -c conda-forge vasp`.

